### PR TITLE
change DateTime to Time so config.time_zone used

### DIFF
--- a/lib/mindbody-api/models/appointment.rb
+++ b/lib/mindbody-api/models/appointment.rb
@@ -3,8 +3,8 @@ module MindBody
     class Appointment < Base
       attribute :id, Integer
       attribute :status, AppointmentStatus
-      attribute :start_date_time, DateTime
-      attribute :end_date_time, DateTime
+      attribute :start_date_time, Time
+      attribute :end_date_time, Time
       attribute :notes, String
       attribute :staff_requested, Boolean
       attribute :program, Program

--- a/lib/mindbody-api/models/class.rb
+++ b/lib/mindbody-api/models/class.rb
@@ -18,8 +18,8 @@ module MindBody
       attribute :is_enrolled, Boolean
       attribute :hide_cancel, Boolean
       attribute :is_available, Boolean
-      attribute :start_date_time, DateTime
-      attribute :end_date_time, DateTime
+      attribute :start_date_time, Time
+      attribute :end_date_time, Time
       attribute :class_description, ClassDescription
       attribute :staff, Staff
 

--- a/lib/mindbody-api/models/client.rb
+++ b/lib/mindbody-api/models/client.rb
@@ -22,7 +22,7 @@ module MindBody
       attribute :home_phone, String
       attribute :photo_url, String
       attribute :username, String
-      attribute :first_appointment_date, DateTime
+      attribute :first_appointment_date, Time
 
       def name
         "#{first_name} #{last_name}"

--- a/lib/mindbody-api/models/client_service.rb
+++ b/lib/mindbody-api/models/client_service.rb
@@ -6,9 +6,9 @@ module MindBody
       attribute :count, Integer
       attribute :remaining, Integer
       attribute :name, String
-      attribute :payment_date, DateTime
-      attribute :active_date, DateTime
-      attribute :expiration_date, DateTime
+      attribute :payment_date, Time
+      attribute :active_date, Time
+      attribute :expiration_date, Time
       attribute :program, Program
     end
   end

--- a/lib/mindbody-api/models/course.rb
+++ b/lib/mindbody-api/models/course.rb
@@ -5,8 +5,8 @@ module MindBody
       attribute :name, String
       attribute :description, String
       attribute :notes, String
-      attribute :start_date, DateTime
-      attribute :end_date, DateTime
+      attribute :start_date, Time
+      attribute :end_date, Time
       attribute :location, Location
       attribute :organizer, Staff
       attribute :program, Program

--- a/lib/mindbody-api/models/semester.rb
+++ b/lib/mindbody-api/models/semester.rb
@@ -2,8 +2,8 @@ module MindBody
   module Models
     class Semester < Base
       attribute :id, Integer
-      attribute :start_date, DateTime
-      attribute :end_date, DateTime
+      attribute :start_date, Time
+      attribute :end_date, Time
     end
   end
 end

--- a/lib/mindbody-api/models/visit.rb
+++ b/lib/mindbody-api/models/visit.rb
@@ -3,8 +3,8 @@ module MindBody
     class Visit < Base
       attribute :id, Integer
       attribute :class_id, Integer
-      attribute :start_date_time, DateTime
-      attribute :end_date_time, DateTime
+      attribute :start_date_time, Time
+      attribute :end_date_time, Time
       attribute :name, String
       attribute :staff, Staff
       attribute :location, Location


### PR DESCRIPTION
DateTime was returning all classes in UTC.  Changing to Time class allows for config.time_zone to set DateTimes from MindBody to proper locale.
