### PR TITLE
Adding configurable open and read timeouts

### DIFF
--- a/lib/mindbody-api.rb
+++ b/lib/mindbody-api.rb
@@ -18,7 +18,7 @@ module MindBody
   end
 
   class Config
-    attr_accessor :log_level, :source_name, :source_key, :site_ids
+    attr_accessor :log_level, :open_timeout, :read_timeout, :source_name, :source_key, :site_ids
 
     def initialize
       @log_level = :debug

--- a/lib/mindbody-api/client.rb
+++ b/lib/mindbody-api/client.rb
@@ -7,6 +7,8 @@ module MindBody
       def call(operation_name, locals = {}, &block)
         # Inject the auth params into the request and setup the
         # correct request structure
+        @globals.open_timeout(MindBody.configuration.open_timeout)
+        @globals.read_timeout(MindBody.configuration.read_timeout)
         @globals.log_level(MindBody.configuration.log_level)
         locals = locals.has_key?(:message) ? locals[:message] : locals
         locals = fixup_locals(locals)


### PR DESCRIPTION
Since 2010 Savon has been using HTTPI, which I believe uses HTTPClient by default, and has no values set for open/read timeouts.

I wanted to be able to set these in the initializer so that I didn't have the possibility of a request hanging for an unknown time.

```
MindBody.configure do |config|
  config.site_ids     = ENV['MINDBODY_SITE_IDS']
  config.source_key   = ENV['MINDBODY_SOURCE_NAME']
  config.source_name  = ENV['MINDBODY_SOURCE_KEY']
  config.open_timeout = 60
  config.read_timeout = 60
end
```

I don't think this should interfere with your work on https://github.com/wingrunr21/mindbody-api/issues/5