### PR TITLE
Allow you to pass savon client configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,16 @@ Alternatively, you may set them in an initializer:
       config.site_ids    = -99
       config.source_key  = 'abcd1234'
       config.source_name = 'SuperFoo'
-      config.log_level   = :info # Savon logging level. Default is :debug, options are [:debug, :info, :warn, :error, :fatal]
+      config.savon_globals[:log_level] = :info # Savon logging level. Default is :debug, options are [:debug, :info, :warn, :error, :fatal]
+      config.savon_globals[:filters] = ['Password'] 
+      # Enable as you see fit
+      # See http://savonrb.com/version2/globals.html for more information settings.
+      #config.savon_globals[:read_timeout] = 0
+      #config.savon_globals[:open_timeout] = 0
+      #config.savon_globals[:pretty_print_xml] = true
+      #config.savon_globals[:log] = true
     end
 
-See http://savonrb.com/version2/globals.html for more information on the logging
-setting.
 
 ## Usage
 

--- a/lib/mindbody-api.rb
+++ b/lib/mindbody-api.rb
@@ -18,10 +18,11 @@ module MindBody
   end
 
   class Config
-    attr_accessor :log_level, :open_timeout, :read_timeout, :source_name, :source_key, :site_ids
+    attr_accessor :log_level, :source_name, :source_key, :site_ids, :open_timeout, :read_timeout, :savon_globals
 
     def initialize
       @log_level = :debug
+      @savon_globals = {}
       @source_name = ENV['MINDBODY_SOURCE_NAME'] || ''
       @source_key = ENV['MINDBODY_SOURCE_KEY'] || ''
       @site_ids = (ENV['MINDBODY_SITE_IDS'] || '').scan(/-?\d+/).map(&:to_i)

--- a/lib/mindbody-api/client.rb
+++ b/lib/mindbody-api/client.rb
@@ -7,9 +7,14 @@ module MindBody
       def call(operation_name, locals = {}, &block)
         # Inject the auth params into the request and setup the
         # correct request structure
+        @globals.log_level(MindBody.configuration.log_level)
         @globals.open_timeout(MindBody.configuration.open_timeout)
         @globals.read_timeout(MindBody.configuration.read_timeout)
-        @globals.log_level(MindBody.configuration.log_level)
+        #Allow you to override Savon global properties
+        MindBody.configuration.savon_globals.each do |key, value|
+          @globals.send(key, value)
+        end
+      
         locals = locals.has_key?(:message) ? locals[:message] : locals
         locals = fixup_locals(locals)
         params = {:message => {'Request' => auth_params.merge(locals)}}

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,6 +7,9 @@ describe MindBody::Services::Client do
     creds.stub(:source_name).and_return('test')
     creds.stub(:source_key).and_return('test_key')
     creds.stub(:site_ids).and_return([-99])
+    creds.stub(:open_timeout).and_return(0)
+    creds.stub(:read_timeout).and_return(0)
+    creds.stub(:savon_globals).and_return({log: false})
     MindBody.stub(:configuration).and_return(creds)
     @client = MindBody::Services::Client.new(:wsdl => 'spec/fixtures/wsdl/geotrust.wsdl')
 

--- a/spec/mindbody_spec.rb
+++ b/spec/mindbody_spec.rb
@@ -30,6 +30,7 @@ describe MindBody::Config do
     it { should respond_to(:source_name) }
     it { should respond_to(:source_key) }
     it { should respond_to(:site_ids) }
+    it { should respond_to(:savon_globals) }
   end
 
   describe '#new' do
@@ -39,6 +40,7 @@ describe MindBody::Config do
       expect(@config.source_name).to eq('')
       expect(@config.source_key).to eq('')
       expect(@config.site_ids).to eq([])
+      expect(@config.savon_globals).to eq({})
     end
 
     it 'should load config data from ENV' do


### PR DESCRIPTION
I fixed the specs as well. 

Hope this is ok? I wanted to make it generic enough to allow you to pass through any configuration options directly to Savon. 

Also updated the readme to include some defaults.