### PR TITLE
Fix master branch specs

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -7,6 +7,8 @@ describe MindBody::Services::Client do
     creds.stub(:source_name).and_return('test')
     creds.stub(:source_key).and_return('test_key')
     creds.stub(:site_ids).and_return([-99])
+    creds.stub(:open_timeout).and_return(0)
+    creds.stub(:read_timeout).and_return(0)
     MindBody.stub(:configuration).and_return(creds)
     @client = MindBody::Services::Client.new(:wsdl => 'spec/fixtures/wsdl/geotrust.wsdl')
 


### PR DESCRIPTION
After pulling down the master branch and running the specs, `spec/client_spec` was failing simply due to the credentials double used receiving timeout messages it wasn't expecting.

I'm assuming these values aren't necessarily important in the context of the spec, so just stub some default values.