### PR TITLE
Extract Savon options into separate key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,28 @@ You must set your MindBody source name, key, and site ids. These values are acce
 The easiest way to set these is via three environment variables: `MINDBODY_SOURCE_NAME`, `MINDBODY_SOURCE_KEY`, and `MINDBODY_SITE_IDS`. `MINDBODY_SITE_IDS` can have any delimiter.
 
 Alternatively, you may set them in an initializer:
+```ruby
+MindBody.configure do |config|
+  config.site_ids    = -99
+  config.source_key  = 'abcd1234'
+  config.source_name = 'SuperFoo'
+end
+```
 
-    MindBody.configure do |config|
-      config.site_ids    = -99
-      config.source_key  = 'abcd1234'
-      config.source_name = 'SuperFoo'
-      config.log_level   = :info # Savon logging level. Default is :debug, options are [:debug, :info, :warn, :error, :fatal]
-    end
+Savon options can be configured the same way:
+```ruby
+MindBody.configure do |config|
+  config.savon_opts.log = true
+  config.savon_opts.log_level = :info # Default is :debug, options are [:debug, :info, :warn, :error, :fatal]
+  config.savon_opts.pretty_print_xml = true
+  # Following options are available in the `savon_opts` and on the top level as well
+  config.log_level = :info
+  config.open_timeout = 10
+  config.read_timeout = 10
+end
+```
 
-See http://savonrb.com/version2/globals.html for more information on the logging
-setting.
+See http://savonrb.com/version2/globals.html for a list of available options.
 
 ## Usage
 
@@ -76,4 +88,3 @@ See the various [issues](https://github.com/wingrunr21/mindbody-api/issues?state
 This gem is written by [Stafford Brunk](https://github.com/wingrunr21)
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/wingrunr21/mindbody-api/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
-

--- a/lib/mindbody-api.rb
+++ b/lib/mindbody-api.rb
@@ -1,3 +1,4 @@
+require 'ostruct'
 require 'active_support/inflector'
 require 'active_support/core_ext/array/extract_options'
 
@@ -30,6 +31,10 @@ module MindBody
     # Make sure site_ids is always an Array
     def site_ids=(ids)
       @site_ids = [*ids]
+    end
+
+    def savon_opts
+      @savon_opts ||= OpenStruct.new
     end
   end
 end

--- a/lib/mindbody-api/client.rb
+++ b/lib/mindbody-api/client.rb
@@ -7,9 +7,18 @@ module MindBody
       def call(operation_name, locals = {}, &block)
         # Inject the auth params into the request and setup the
         # correct request structure
-        @globals.open_timeout(MindBody.configuration.open_timeout)
-        @globals.read_timeout(MindBody.configuration.read_timeout)
-        @globals.log_level(MindBody.configuration.log_level)
+        savon_opts = MindBody.configuration.savon_opts.to_h
+        # add top-level options
+        savon_opts.merge!({
+          open_timeout: MindBody.configuration.open_timeout,
+          read_timeout: MindBody.configuration.read_timeout,
+          log_level: MindBody.configuration.log_level
+        })
+
+        savon_opts.each do |k, v|
+          @globals.send("#{ k }", v) if @globals.respond_to?(k)
+        end
+
         locals = locals.has_key?(:message) ? locals[:message] : locals
         locals = fixup_locals(locals)
         params = {:message => {'Request' => auth_params.merge(locals)}}

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -9,6 +9,7 @@ describe MindBody::Services::Client do
     creds.stub(:site_ids).and_return([-99])
     creds.stub(:open_timeout).and_return(0)
     creds.stub(:read_timeout).and_return(0)
+    creds.stub(:savon_opts).and_return(OpenStruct.new)
     MindBody.stub(:configuration).and_return(creds)
     @client = MindBody::Services::Client.new(:wsdl => 'spec/fixtures/wsdl/geotrust.wsdl')
 


### PR DESCRIPTION
This allows to pass any global option to Savon. Options are extracted to a separate key to avoid polluting top-level configuration. Existing options (`log_level`, `open_timeout`, `read_timeout`) are kept in place for compatibility.
