### PR TITLE
Add missing API operations and parameter mappings

### DIFF
--- a/lib/mindbody-api/models/client.rb
+++ b/lib/mindbody-api/models/client.rb
@@ -23,6 +23,8 @@ module MindBody
       attribute :photo_url, String
       attribute :username, String
       attribute :first_appointment_date, DateTime
+      attribute :action, String
+      attribute :referred_by, String
 
       def name
         "#{first_name} #{last_name}"

--- a/lib/mindbody-api/models/visit.rb
+++ b/lib/mindbody-api/models/visit.rb
@@ -13,6 +13,7 @@ module MindBody
       attribute :signed_in, Boolean
       attribute :make_up, Boolean
       attribute :service, ClientService
+      attribute :late_cancelled, Boolean
     end
   end
 end

--- a/lib/mindbody-api/services/class_service.rb
+++ b/lib/mindbody-api/services/class_service.rb
@@ -3,10 +3,12 @@ module MindBody
     class ClassService < Service
       service "ClassService"
 
+      operation :add_clients_to_classes
       operation :get_classes
       operation :get_class_visits,           required:[:class_id]
       operation :get_class_descriptions
       operation :get_class_schedules
+      operation :remove_clients_from_classes
     end
   end
 end

--- a/lib/mindbody-api/services/sale_service.rb
+++ b/lib/mindbody-api/services/sale_service.rb
@@ -3,6 +3,7 @@ module MindBody
     class SaleService < Service
       service "SaleService"
 
+      operation :checkout_shopping_cart
       operation :get_accepted_card_type,      :locals => false
       operation :get_sales
       operation :get_services

--- a/spec/models/client_spec.rb
+++ b/spec/models/client_spec.rb
@@ -24,6 +24,8 @@ describe MindBody::Models::Client do
   it {should respond_to(:username)}
   it {should respond_to(:first_appointment_date)}
   it {should respond_to(:name)}
+  it {should respond_to(:action)}
+  it {should respond_to(:referred_by)}
 
   it 'should concatenate first_name and last_name to be name' do
     subject.first_name = "Bob"

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -13,4 +13,5 @@ describe MindBody::Models::Visit do
   it { should respond_to(:signed_in) }
   it { should respond_to(:make_up) }
   it { should respond_to(:service) }
+  it { should respond_to(:late_cancelled) }
 end

--- a/spec/services/class_service_spec.rb
+++ b/spec/services/class_service_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe MindBody::Services::ClassService do
   subject { MindBody::Services::ClassService }
 
+  it { should respond_to(:add_clients_to_classes) }
   it { should respond_to(:get_classes) }
   it { should respond_to(:get_class_visits) }
   it { should respond_to(:get_class_descriptions) }
   it { should respond_to(:get_class_schedules) }
+  it { should respond_to(:remove_clients_from_classes) }
 end

--- a/spec/services/sale_service_spec.rb
+++ b/spec/services/sale_service_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe MindBody::Services::SaleService do
   subject { MindBody::Services::SaleService }
 
+  it { should respond_to(:checkout_shopping_cart) }
   it { should respond_to(:get_accepted_card_type) }
   it { should respond_to(:get_sales) }
   it { should respond_to(:get_services) }


### PR DESCRIPTION
This PR adds three API operations that are missing:

* ClassService.add_clients_to_classes
* ClassService. remove_clients_from_classes
* SaleService.checkout_shopping_cart

Also adding three attributes that were missing from the `Client` and `Visit` models:

* Client: action, referred_by
* Visit: late_cancelled

I've had these changes monkey-patched for a while in my app that uses this gem and just wanted to submit here in case others could use them. Cheers.